### PR TITLE
matching: add taskSource param to addTask APIs

### DIFF
--- a/thrift/matching.thrift
+++ b/thrift/matching.thrift
@@ -24,7 +24,7 @@ namespace java com.uber.cadence.matching
 
 // TaskSource is the source from which a task was produced
 enum TaskSource {
-    HISTORY    // Task produced by history service
+    HISTORY,    // Task produced by history service
     DB_BACKLOG // Task produced from matching db backlog
 }
 

--- a/thrift/matching.thrift
+++ b/thrift/matching.thrift
@@ -22,6 +22,12 @@ include "shared.thrift"
 
 namespace java com.uber.cadence.matching
 
+// TaskSource is the source from which a task was produced
+enum TaskSource {
+    HISTORY    // Task produced by history service
+    DB_BACKLOG // Task produced from matching db backlog
+}
+
 struct PollForDecisionTaskRequest {
   10: optional string domainUUID
   15: optional string pollerID
@@ -62,6 +68,7 @@ struct AddDecisionTaskRequest {
   30: optional shared.TaskList taskList
   40: optional i64 (js.type = "Long") scheduleId
   50: optional i32 scheduleToStartTimeoutSeconds
+  59: optional TaskSource source
   60: optional string forwardedFrom
 }
 
@@ -72,6 +79,7 @@ struct AddActivityTaskRequest {
   40: optional shared.TaskList taskList
   50: optional i64 (js.type = "Long") scheduleId
   60: optional i32 scheduleToStartTimeoutSeconds
+  69: optional TaskSource source
   70: optional string forwardedFrom
 }
 


### PR DESCRIPTION
This patch adds a taskSource param to AddTask API request structs. The task source for now is either (1) history service or (2) matching db_backlog. This param will be used by the implementation of scalable task list i.e. when child partitions attempt remote-sync-match with parent partition, this info is needed to decide if certain operations can be performed. 