### PR TITLE
Ping fossa version for fixing buildkite issue

### DIFF
--- a/scripts/buildkite/fossa.sh
+++ b/scripts/buildkite/fossa.sh
@@ -2,7 +2,7 @@
 
 set -exo pipefail
 
-curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/fossa-cli/master/install.sh | bash -s -- -b ~/
+curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/fossa-cli/v1.0.22/install.sh | bash -s -- -b ~/ v1.0.22
 
 ~/fossa init
 ~/fossa analyze


### PR DESCRIPTION
The latest fossa install script will also install https://github.com/fossas/spectrometer (https://github.com/fossas/fossa-cli/pull/568). However the script will install it to the default path `/usr/local/bin` where we don't have access to on buildkite agent. 

Fossa Issue for tracking: https://github.com/fossas/fossa-cli/issues/587

This pr ping fossa to an old version so that build can pass on buildkite.  