### PR TITLE
Use fossa install script from master

### DIFF
--- a/scripts/buildkite/fossa.sh
+++ b/scripts/buildkite/fossa.sh
@@ -2,7 +2,7 @@
 
 set -exo pipefail
 
-curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/fossa-cli/v1.0.22/install.sh | bash -s -- -b ~/ v1.0.22
+curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/fossa-cli/master/install.sh | bash -s -- -b ~/
 
 ~/fossa init
 ~/fossa analyze


### PR DESCRIPTION
https://github.com/uber/cadence-idl/pull/22 ping fossa to an old version as a temporarily workaround for https://github.com/fossas/fossa-cli/issues/587

Now that fossa team has fixed the issue, we can continue to use the latest install script and fossa release.