### PR TITLE
Add rawHistorySupported flag for backward compatability

### DIFF
--- a/thrift/shared.thrift
+++ b/thrift/shared.thrift
@@ -1258,6 +1258,7 @@ struct GetWorkflowExecutionHistoryRequest {
   50: optional bool waitForNewEvent
   60: optional HistoryEventFilterType HistoryEventFilterType
   70: optional bool skipArchival
+  80: optional bool rawHistorySupported
 }
 
 struct GetWorkflowExecutionHistoryResponse {


### PR DESCRIPTION
Added rawHistorySupported flag on GetWorkflowExecutionHistoryRequest to make backward compatibility with the client.