### PR TITLE
Add notify failover marker API thrift

### DIFF
--- a/thrift/history.thrift
+++ b/thrift/history.thrift
@@ -354,6 +354,15 @@ struct ReapplyEventsRequest {
   20: optional shared.ReapplyEventsRequest request
 }
 
+struct FailoverMarkerToken {
+  10: optional list<i32> shardIDs
+  20: optional replicator.FailoverMarkerAttributes failoverMarker
+}
+
+struct HeartbeatFailoverMarkersRequest {
+  10: optional list<FailoverMarkerToken> failoverMarkerTokens
+}
+
 /**
 * HistoryService provides API to start a new long running workflow instance, as well as query and update the history
 * of workflow instances already created.
@@ -910,5 +919,15 @@ service HistoryService {
       3: shared.ServiceBusyError serviceBusyError,
       4: shared.EntityNotExistsError entityNotExistError,
       5: ShardOwnershipLostError shardOwnershipLostError,
+    )
+
+  /**
+  * HeartbeatFailoverMarkers sends failover marker to the failover coordinator
+  **/
+  void HeartbeatFailoverMarkers(1: HeartbeatFailoverMarkersRequest request)
+    throws (
+      1: shared.BadRequestError badRequestError,
+      2: shared.InternalServiceError internalServiceError,
+      3: shared.ServiceBusyError serviceBusyError,
     )
 }

--- a/thrift/history.thrift
+++ b/thrift/history.thrift
@@ -359,7 +359,7 @@ struct FailoverMarkerToken {
   20: optional replicator.FailoverMarkerAttributes failoverMarker
 }
 
-struct HeartbeatFailoverMarkersRequest {
+struct NotifyFailoverMarkersRequest {
   10: optional list<FailoverMarkerToken> failoverMarkerTokens
 }
 
@@ -922,9 +922,9 @@ service HistoryService {
     )
 
   /**
-  * HeartbeatFailoverMarkers sends failover marker to the failover coordinator
+  * NotifyFailoverMarkers sends failover marker to the failover coordinator
   **/
-  void HeartbeatFailoverMarkers(1: HeartbeatFailoverMarkersRequest request)
+  void NotifyFailoverMarkers(1: NotifyFailoverMarkersRequest request)
     throws (
       1: shared.BadRequestError badRequestError,
       2: shared.InternalServiceError internalServiceError,

--- a/thrift/replicator.thrift
+++ b/thrift/replicator.thrift
@@ -112,8 +112,7 @@ struct HistoryTaskV2Attributes {
 struct FailoverMarkerAttributes{
 	10: optional string domainID
 	20: optional i64 (js.type = "Long") failoverVersion
-	30: optional string sourceCluster
-	40: optional i64 (js.type = "Long") creationTime
+	30: optional i64 (js.type = "Long") creationTime
 }
 
 struct ReplicationTask {


### PR DESCRIPTION
Add notify failover marker API thrift. This API uses to send the failover markers to the failover coordinator. The coordinator tracks the received marker and decides when to move the domain to active