### PR TITLE
Add reset option: skipSignalReapply 

### DIFF
--- a/thrift/shared.thrift
+++ b/thrift/shared.thrift
@@ -1316,7 +1316,6 @@ struct ResetWorkflowExecutionRequest {
   40: optional i64 (js.type = "Long") decisionFinishEventId
   50: optional string requestId
   60: optional bool skipSignalReapply
-  70: optional bool convertCompletedActivityToSignal
 }
 
 struct ResetWorkflowExecutionResponse {

--- a/thrift/shared.thrift
+++ b/thrift/shared.thrift
@@ -1315,6 +1315,8 @@ struct ResetWorkflowExecutionRequest {
   30: optional string reason
   40: optional i64 (js.type = "Long") decisionFinishEventId
   50: optional string requestId
+  60: optional bool skipSignalReapply
+  70: optional bool convertCompletedActivityToSignal
 }
 
 struct ResetWorkflowExecutionResponse {


### PR DESCRIPTION
For https://github.com/uber/cadence/issues/3556 
`skipSignalReapply` will allow skipping the reapplication of signals after reset point. 