### PR TITLE
Apply new error change to history.thrift

### DIFF
--- a/thrift/history.thrift
+++ b/thrift/history.thrift
@@ -577,6 +577,7 @@ service HistoryService {
       5: shared.DomainNotActiveError domainNotActiveError,
       6: shared.ServiceBusyError serviceBusyError,
       7: shared.LimitExceededError limitExceededError,
+      8: shared.WorkflowExecutionAlreadyCompletedError workflowExecutionAlreadyCompletedError,
     )
 
   /**
@@ -626,6 +627,7 @@ service HistoryService {
       5: shared.DomainNotActiveError domainNotActiveError,
       6: shared.LimitExceededError limitExceededError,
       7: shared.ServiceBusyError serviceBusyError,
+      8: shared.WorkflowExecutionAlreadyCompletedError workflowExecutionAlreadyCompletedError,
     )
 
   /**
@@ -647,8 +649,9 @@ service HistoryService {
   /**
   * RequestCancelWorkflowExecution is called by application worker when it wants to request cancellation of a workflow instance.
   * It will result in a new 'WorkflowExecutionCancelRequested' event being written to the workflow history and a new DecisionTask
-  * created for the workflow instance so new decisions could be made. It fails with 'EntityNotExistsError' if the workflow is not valid
-  * anymore due to completion or doesn't exist.
+  * created for the workflow instance so new decisions could be made. It fails with
+  * 'WorkflowExecutionAlreadyCompletedError' if the workflow is not valid
+  * anymore due to completion or with 'EntityNotExistsError' if worfklow doesn't exist.
   **/
   void RequestCancelWorkflowExecution(1: RequestCancelWorkflowExecutionRequest cancelRequest)
     throws (
@@ -660,6 +663,7 @@ service HistoryService {
       6: shared.DomainNotActiveError domainNotActiveError,
       7: shared.LimitExceededError limitExceededError,
       8: shared.ServiceBusyError serviceBusyError,
+      10: shared.WorkflowExecutionAlreadyCompletedError workflowExecutionAlreadyCompletedError,
     )
 
   /**
@@ -787,7 +791,7 @@ service HistoryService {
     )
 
   /**
-  * ResetQueue reset processing queue state based on cluster name and type 
+  * ResetQueue reset processing queue state based on cluster name and type
   **/
   void ResetQueue(1: shared.ResetQueueRequest request)
     throws (
@@ -797,7 +801,7 @@ service HistoryService {
     )
 
   /**
-  * DescribeQueue return queue states based on cluster name and type 
+  * DescribeQueue return queue states based on cluster name and type
   **/
   shared.DescribeQueueResponse DescribeQueue(1: shared.DescribeQueueRequest request)
     throws (


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
History.thrift changes for the new WorkflowExecutionAlreadyCompletedError were missing in this commit (https://github.com/uber/cadence-idl/pull/60). With this diff we also apply the new error to the idl branch.

<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
