### PR TITLE
Expand workflowAlreadyCompletedError to other apis

### DIFF
--- a/thrift/cadence.thrift
+++ b/thrift/cadence.thrift
@@ -155,6 +155,7 @@ service WorkflowService {
       5: shared.LimitExceededError limitExceededError,
       6: shared.ServiceBusyError serviceBusyError,
       7: shared.ClientVersionNotSupportedError clientVersionNotSupportedError,
+      8: shared.WorkflowExecutionAlreadyCompletedError workflowExecutionAlreadyCompletedError,
     )
 
   /**
@@ -171,6 +172,7 @@ service WorkflowService {
       5: shared.LimitExceededError limitExceededError,
       6: shared.ServiceBusyError serviceBusyError,
       7: shared.ClientVersionNotSupportedError clientVersionNotSupportedError,
+      8: shared.WorkflowExecutionAlreadyCompletedError workflowExecutionAlreadyCompletedError,
     )
 
   /**
@@ -207,6 +209,7 @@ service WorkflowService {
       5: shared.LimitExceededError limitExceededError,
       6: shared.ServiceBusyError serviceBusyError,
       7: shared.ClientVersionNotSupportedError clientVersionNotSupportedError,
+      8: shared.WorkflowExecutionAlreadyCompletedError workflowExecutionAlreadyCompletedError,
     )
 
   /**
@@ -224,6 +227,7 @@ service WorkflowService {
       5: shared.LimitExceededError limitExceededError,
       6: shared.ServiceBusyError serviceBusyError,
       7: shared.ClientVersionNotSupportedError clientVersionNotSupportedError,
+      8: shared.WorkflowExecutionAlreadyCompletedError workflowExecutionAlreadyCompletedError,
     )
 
   /**
@@ -241,6 +245,7 @@ service WorkflowService {
       5: shared.LimitExceededError limitExceededError,
       6: shared.ServiceBusyError serviceBusyError,
       7: shared.ClientVersionNotSupportedError clientVersionNotSupportedError,
+      8: shared.WorkflowExecutionAlreadyCompletedError workflowExecutionAlreadyCompletedError,
     )
 
   /**
@@ -258,6 +263,7 @@ service WorkflowService {
       5: shared.LimitExceededError limitExceededError,
       6: shared.ServiceBusyError serviceBusyError,
       7: shared.ClientVersionNotSupportedError clientVersionNotSupportedError,
+      8: shared.WorkflowExecutionAlreadyCompletedError workflowExecutionAlreadyCompletedError,
     )
 
   /**
@@ -275,6 +281,7 @@ service WorkflowService {
       5: shared.LimitExceededError limitExceededError,
       6: shared.ServiceBusyError serviceBusyError,
       7: shared.ClientVersionNotSupportedError clientVersionNotSupportedError,
+      8: shared.WorkflowExecutionAlreadyCompletedError workflowExecutionAlreadyCompletedError,
     )
 
   /**
@@ -292,6 +299,7 @@ service WorkflowService {
       5: shared.LimitExceededError limitExceededError,
       6: shared.ServiceBusyError serviceBusyError,
       7: shared.ClientVersionNotSupportedError clientVersionNotSupportedError,
+      8: shared.WorkflowExecutionAlreadyCompletedError workflowExecutionAlreadyCompletedError,
     )
 
   /**
@@ -309,6 +317,7 @@ service WorkflowService {
       5: shared.LimitExceededError limitExceededError,
       6: shared.ServiceBusyError serviceBusyError,
       7: shared.ClientVersionNotSupportedError clientVersionNotSupportedError,
+      8: shared.WorkflowExecutionAlreadyCompletedError workflowExecutionAlreadyCompletedError,
     )
 
   /**
@@ -326,6 +335,7 @@ service WorkflowService {
       5: shared.LimitExceededError limitExceededError,
       6: shared.ServiceBusyError serviceBusyError,
       7: shared.ClientVersionNotSupportedError clientVersionNotSupportedError,
+      8: shared.WorkflowExecutionAlreadyCompletedError workflowExecutionAlreadyCompletedError,
     )
 
   /**
@@ -516,6 +526,7 @@ service WorkflowService {
       5: shared.ServiceBusyError serviceBusyError,
       6: shared.DomainNotActiveError domainNotActiveError,
       7: shared.ClientVersionNotSupportedError clientVersionNotSupportedError,
+      8: shared.WorkflowExecutionAlreadyCompletedError workflowExecutionAlreadyCompletedError,
     )
 
   /**
@@ -527,8 +538,8 @@ service WorkflowService {
 	  3: shared.EntityNotExistsError entityNotExistError,
 	  4: shared.QueryFailedError queryFailedError,
 	  5: shared.LimitExceededError limitExceededError,
-      6: shared.ServiceBusyError serviceBusyError,
-      7: shared.ClientVersionNotSupportedError clientVersionNotSupportedError,
+	  6: shared.ServiceBusyError serviceBusyError,
+	  7: shared.ClientVersionNotSupportedError clientVersionNotSupportedError,
 	)
 
   /**

--- a/thrift/history.thrift
+++ b/thrift/history.thrift
@@ -422,6 +422,7 @@ service HistoryService {
       4: ShardOwnershipLostError shardOwnershipLostError,
       5: shared.LimitExceededError limitExceededError,
       6: shared.ServiceBusyError serviceBusyError,
+      7: shared.WorkflowExecutionAlreadyCompletedError workflowExecutionAlreadyCompletedError,
     )
 
   /**
@@ -439,6 +440,7 @@ service HistoryService {
       6: shared.DomainNotActiveError domainNotActiveError,
       7: shared.LimitExceededError limitExceededError,
       8: shared.ServiceBusyError serviceBusyError,
+      9: shared.WorkflowExecutionAlreadyCompletedError workflowExecutionAlreadyCompletedError,
     )
 
   /**
@@ -456,6 +458,7 @@ service HistoryService {
       6: shared.DomainNotActiveError domainNotActiveError,
       7: shared.LimitExceededError limitExceededError,
       8: shared.ServiceBusyError serviceBusyError,
+      9: shared.WorkflowExecutionAlreadyCompletedError workflowExecutionAlreadyCompletedError,
     )
 
   /**
@@ -474,6 +477,7 @@ service HistoryService {
       5: shared.DomainNotActiveError domainNotActiveError,
       6: shared.LimitExceededError limitExceededError,
       7: shared.ServiceBusyError serviceBusyError,
+      8: shared.WorkflowExecutionAlreadyCompletedError workflowExecutionAlreadyCompletedError,
     )
 
   /**
@@ -490,6 +494,7 @@ service HistoryService {
       5: shared.DomainNotActiveError domainNotActiveError,
       6: shared.LimitExceededError limitExceededError,
       7: shared.ServiceBusyError serviceBusyError,
+      8: shared.WorkflowExecutionAlreadyCompletedError workflowExecutionAlreadyCompletedError,
     )
 
   /**
@@ -508,6 +513,7 @@ service HistoryService {
       5: shared.DomainNotActiveError domainNotActiveError,
       6: shared.LimitExceededError limitExceededError,
       7: shared.ServiceBusyError serviceBusyError,
+      8: shared.WorkflowExecutionAlreadyCompletedError workflowExecutionAlreadyCompletedError,
     )
 
   /**
@@ -526,6 +532,7 @@ service HistoryService {
       5: shared.DomainNotActiveError domainNotActiveError,
       6: shared.LimitExceededError limitExceededError,
       7: shared.ServiceBusyError serviceBusyError,
+      8: shared.WorkflowExecutionAlreadyCompletedError workflowExecutionAlreadyCompletedError,
     )
 
   /**
@@ -544,6 +551,7 @@ service HistoryService {
       5: shared.DomainNotActiveError domainNotActiveError,
       6: shared.LimitExceededError limitExceededError,
       7: shared.ServiceBusyError serviceBusyError,
+      8: shared.WorkflowExecutionAlreadyCompletedError workflowExecutionAlreadyCompletedError,
     )
 
   /**
@@ -562,6 +570,7 @@ service HistoryService {
       5: shared.DomainNotActiveError domainNotActiveError,
       6: shared.LimitExceededError limitExceededError,
       7: shared.ServiceBusyError serviceBusyError,
+      8: shared.WorkflowExecutionAlreadyCompletedError workflowExecutionAlreadyCompletedError,
     )
 
   /**
@@ -612,6 +621,7 @@ service HistoryService {
       5: shared.DomainNotActiveError domainNotActiveError,
       6: shared.LimitExceededError limitExceededError,
       7: shared.ServiceBusyError serviceBusyError,
+      8: shared.WorkflowExecutionAlreadyCompletedError workflowExecutionAlreadyCompletedError,
     )
 
   /**
@@ -681,6 +691,7 @@ service HistoryService {
       5: shared.DomainNotActiveError domainNotActiveError,
       6: shared.LimitExceededError limitExceededError,
       7: shared.ServiceBusyError serviceBusyError,
+      8: shared.WorkflowExecutionAlreadyCompletedError workflowExecutionAlreadyCompletedError,
     )
 
   /**
@@ -696,6 +707,7 @@ service HistoryService {
       5: shared.DomainNotActiveError domainNotActiveError,
       6: shared.LimitExceededError limitExceededError,
       7: shared.ServiceBusyError serviceBusyError,
+      8: shared.WorkflowExecutionAlreadyCompletedError workflowExecutionAlreadyCompletedError,
     )
 
   /**


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
`WorkflowExecutionAlreadyCompletedError` was originally thought for SignalWorkflow, CancelWorkflow and TerminateWorkflow. To have a consistent behavior with consistent states from the other APIs, expanding this error to some other APIs.

See https://github.com/uber/cadence/pull/4123/ for more details.

Following functions support `EntityNotExistsError` but doesn't seem to need `WorkflowExecutionAlreadyCompletedError`. Please check the list below and let me know if we need to support the new error for some of those functions 
```
cadence.thrift:
- DescribeDomain
- ListDomains
- UpdateDomain
- DeprecateDomain
- GetWorkflowExecutionHistory ? 
- ListOpenWorkflowExecutions
- ListClosedWorkflowExecutions
- ListWorkflowExecutions
- ListArchivedWorkflowExecutions
- ScanWorkflowExecutions
- CountWorkflowExecutions
- QueryWorkflow
- DescribeWorkflowExecution
- DescribeTaskList
- ListTaskListPartitions


history.thrift:
- GetMutableState
- PollMutableState
- DescribeWorkflowExecution
- ReplicateEventsV2
- DescribeMutableState
- GetDLQReplicationMessages
- QueryWorkflow
- ReapplyEvents
- RefreshWorkflowTasks
- ReadDLQMessages
- PurgeDLQMessages
- MergeDLQMessages

matching.thrift
- RespondQueryTaskCompleted
- DescribeTaskList
```

<!-- Tell your future self why have you made these changes -->
**Why?**

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
