### PR TITLE
Add isCron field to WorkflowExecutionInfo

### DIFF
--- a/proto/uber/cadence/api/v1/workflow.proto
+++ b/proto/uber/cadence/api/v1/workflow.proto
@@ -45,6 +45,7 @@ message WorkflowExecutionInfo {
   SearchAttributes search_attributes = 10;
   ResetPoints auto_reset_points = 11;
   string task_list = 12;
+  bool is_cron = 13;
 }
 
 message WorkflowExecutionConfiguration {

--- a/thrift/shared.thrift
+++ b/thrift/shared.thrift
@@ -389,6 +389,7 @@ struct WorkflowExecutionInfo {
   101: optional SearchAttributes searchAttributes
   110: optional ResetPoints autoResetPoints
   120: optional string taskList
+  130: optional bool isCron
 }
 
 struct WorkflowExecutionConfiguration {


### PR DESCRIPTION
This field is needed so CLI commands for ElasticSearch can work properly. ListWorkflow calls share information between the server and client through WorkflowExecutionInfo