### PR TITLE
Switch proto rpcs between services

### DIFF
--- a/proto/uber/cadence/api/v1/service_worker.proto
+++ b/proto/uber/cadence/api/v1/service_worker.proto
@@ -136,11 +136,14 @@ service WorkerAPI {
   // API and return the query result to client as a response to 'QueryWorkflow' API call.
   rpc RespondQueryTaskCompleted(RespondQueryTaskCompletedRequest) returns (RespondQueryTaskCompletedResponse);
 
-  // RequestCancelWorkflowExecution is called by application worker when it wants to request cancellation of a workflow
-  // instance. It will result in a new 'WorkflowExecutionCancelRequested' event being written to the workflow history
-  // and a new DecisionTask created for the workflow instance so new decisions could be made. It fails with
-  // 'EntityNotExistsError' if the workflow is not valid anymore due to completion or doesn't exist.
-  rpc RequestCancelWorkflowExecution(RequestCancelWorkflowExecutionRequest) returns (RequestCancelWorkflowExecutionResponse);
+  // Reset the sticky tasklist related information in mutable state of a given workflow.
+  // Things cleared are:
+  // 1. StickyTaskList
+  // 2. StickyScheduleToStartTimeout
+  // 3. ClientLibraryVersion
+  // 4. ClientFeatureVersion
+  // 5. ClientImpl
+  rpc ResetStickyTaskList(ResetStickyTaskListRequest) returns(ResetStickyTaskListResponse);
 }
 
 message PollForDecisionTaskRequest {
@@ -313,12 +316,10 @@ message RespondQueryTaskCompletedRequest {
 message RespondQueryTaskCompletedResponse {
 }
 
-message RequestCancelWorkflowExecutionRequest {
+message ResetStickyTaskListRequest {
   string domain = 1;
   WorkflowExecution workflow_execution = 2;
-  string identity = 3;
-  string request_id = 4;
 }
 
-message RequestCancelWorkflowExecutionResponse {
+message ResetStickyTaskListResponse {
 }

--- a/proto/uber/cadence/api/v1/service_workflow.proto
+++ b/proto/uber/cadence/api/v1/service_workflow.proto
@@ -55,6 +55,10 @@ service WorkflowAPI {
   // And it will immediately terminating the current execution instance.
   rpc ResetWorkflowExecution(ResetWorkflowExecutionRequest) returns (ResetWorkflowExecutionResponse);
 
+  // RequestCancelWorkflowExecution requests cancellation of a workflow instance.
+  // It allows workflow to properly clean up and gracefully close.
+  rpc RequestCancelWorkflowExecution(RequestCancelWorkflowExecutionRequest) returns (RequestCancelWorkflowExecutionResponse);
+
   // TerminateWorkflowExecution terminates an existing workflow execution by recording WorkflowExecutionTerminated event
   // in the history and immediately terminating the execution instance.
   rpc TerminateWorkflowExecution(TerminateWorkflowExecutionRequest) returns (TerminateWorkflowExecutionResponse);
@@ -71,15 +75,6 @@ service WorkflowAPI {
 
   // ListTaskListPartitions returns information about task list partitions.
   rpc ListTaskListPartitions(ListTaskListPartitionsRequest) returns(ListTaskListPartitionsResponse);
-
-  // Reset the sticky tasklist related information in mutable state of a given workflow.
-  // Things cleared are:
-  // 1. StickyTaskList
-  // 2. StickyScheduleToStartTimeout
-  // 3. ClientLibraryVersion
-  // 4. ClientFeatureVersion
-  // 5. ClientImpl
-  rpc ResetStickyTaskList(ResetStickyTaskListRequest) returns(ResetStickyTaskListResponse);
 
   // GetClusterInfo returns information about cadence cluster.
   rpc GetClusterInfo(GetClusterInfoRequest) returns(GetClusterInfoResponse);
@@ -150,6 +145,16 @@ message ResetWorkflowExecutionResponse {
   string run_id = 1;
 }
 
+message RequestCancelWorkflowExecutionRequest {
+  string domain = 1;
+  WorkflowExecution workflow_execution = 2;
+  string identity = 3;
+  string request_id = 4;
+}
+
+message RequestCancelWorkflowExecutionResponse {
+}
+
 message TerminateWorkflowExecutionRequest {
   string domain = 1;
   WorkflowExecution workflow_execution = 2;
@@ -207,14 +212,6 @@ message ListTaskListPartitionsRequest {
 message ListTaskListPartitionsResponse {
   repeated TaskListPartitionMetadata activity_task_list_partitions = 1;
   repeated TaskListPartitionMetadata decision_task_list_partitions = 2;
-}
-
-message ResetStickyTaskListRequest {
-  string domain = 1;
-  WorkflowExecution workflow_execution = 2;
-}
-
-message ResetStickyTaskListResponse {
 }
 
 message GetClusterInfoRequest {


### PR DESCRIPTION
A couple of RPCs were misplaced in the wrong service during initial api iteration.
- Move `RequestCancelWorkflowExecution` to `WorkflowService`. This is not part or the worker. User may cancel workflow execution from the client.
- Move `ResetStickyTaskList` to `WorkerService`. This is only used by the worker.

At this point we can still do this change. Clients are not yet released so we will not break them.