### PR TITLE
Change ListX Requests to Filter Cron Workflows

### DIFF
--- a/proto/uber/cadence/api/v1/service_visibility.proto
+++ b/proto/uber/cadence/api/v1/service_visibility.proto
@@ -59,6 +59,7 @@ message ListWorkflowExecutionsRequest {
   int32 page_size = 2;
   bytes next_page_token = 3;
   string query = 4;
+  bool is_cron = 5;
 }
 
 message ListWorkflowExecutionsResponse {
@@ -75,6 +76,7 @@ message ListOpenWorkflowExecutionsRequest {
     WorkflowExecutionFilter execution_filter = 5;
     WorkflowTypeFilter type_filter = 6;
   }
+  bool is_cron = 7;
 }
 
 message ListOpenWorkflowExecutionsResponse {
@@ -92,6 +94,7 @@ message ListClosedWorkflowExecutionsRequest {
     WorkflowTypeFilter type_filter = 6;
     StatusFilter status_filter = 7;
   }
+  bool is_cron = 8;
 }
 
 message ListClosedWorkflowExecutionsResponse {
@@ -104,6 +107,7 @@ message ListArchivedWorkflowExecutionsRequest {
   int32 page_size = 2;
   bytes next_page_token = 3;
   string query = 4;
+  bool is_cron = 5;
 }
 
 message ListArchivedWorkflowExecutionsResponse {

--- a/thrift/shared.thrift
+++ b/thrift/shared.thrift
@@ -1357,6 +1357,7 @@ struct ListOpenWorkflowExecutionsRequest {
   40: optional StartTimeFilter StartTimeFilter
   50: optional WorkflowExecutionFilter executionFilter
   60: optional WorkflowTypeFilter typeFilter
+  70: optional bool isCron
 }
 
 struct ListOpenWorkflowExecutionsResponse {
@@ -1372,6 +1373,7 @@ struct ListClosedWorkflowExecutionsRequest {
   50: optional WorkflowExecutionFilter executionFilter
   60: optional WorkflowTypeFilter typeFilter
   70: optional WorkflowExecutionCloseStatus statusFilter
+  80: optional bool isCron
 }
 
 struct ListClosedWorkflowExecutionsResponse {
@@ -1384,6 +1386,7 @@ struct ListWorkflowExecutionsRequest {
   20: optional i32 pageSize
   30: optional binary nextPageToken
   40: optional string query
+  50: optional bool isCron
 }
 
 struct ListWorkflowExecutionsResponse {
@@ -1396,6 +1399,7 @@ struct ListArchivedWorkflowExecutionsRequest {
   20: optional i32 pageSize
   30: optional binary nextPageToken
   40: optional string query
+  50: optional bool isCron
 }
 
 struct ListArchivedWorkflowExecutionsResponse {


### PR DESCRIPTION
Changing List workflow requests so we can filter workflows based on whether they are cron or non-cron workflows