### PR TITLE
Improve definition for cross-cluster related endpoints

### DIFF
--- a/thrift/shared.thrift
+++ b/thrift/shared.thrift
@@ -1738,7 +1738,7 @@ enum CrossClusterTaskFailedCause {
   UNCATEGORIZED
 }
 
-enum GetCrossClusterTaskFailedCause {
+enum GetTaskFailedCause {
   SERVICE_BUSY
   TIMEOUT
   SHARD_OWNERSHIP_LOST
@@ -1819,7 +1819,7 @@ struct GetCrossClusterTasksRequest {
 
 struct GetCrossClusterTasksResponse {
   10: optional map<i32, list<CrossClusterTaskRequest>> tasksByShard
-  20: optional map<i32, GetCrossClusterTaskFailedCause> failedCauseByShard
+  20: optional map<i32, GetTaskFailedCause> failedCauseByShard
 }
 
 struct RespondCrossClusterTasksCompletedRequest {

--- a/thrift/shared.thrift
+++ b/thrift/shared.thrift
@@ -1734,6 +1734,15 @@ enum CrossClusterTaskFailedCause {
   DOMAIN_NOT_EXISTS
   WORKFLOW_ALREADY_RUNNING
   WORKFLOW_NOT_EXISTS
+  WORKFLOW_ALREADY_COMPLETED
+  UNCATEGORIZED
+}
+
+enum GetCrossClusterTaskFailedCause {
+  SERVICE_BUSY
+  TIMEOUT
+  SHARD_OWNERSHIP_LOST
+  UNCATEGORIZED
 }
 
 struct CrossClusterTaskInfo {
@@ -1810,12 +1819,14 @@ struct GetCrossClusterTasksRequest {
 
 struct GetCrossClusterTasksResponse {
   10: optional map<i32, list<CrossClusterTaskRequest>> tasksByShard
+  20: optional map<i32, GetCrossClusterTaskFailedCause> failedCauseByShard
 }
 
 struct RespondCrossClusterTasksCompletedRequest {
   10: optional i32 shardID
   20: optional string targetCluster
   30: optional list<CrossClusterTaskResponse> taskResponses
+  40: optional bool fetchNewTasks
 }
 
 struct RespondCrossClusterTasksCompletedResponse {


### PR DESCRIPTION
- Add Workflow_Already_Completed and Uncategorized type for CrossClusterTaskFailed Cause
- Add per shard failed cause for getting cross cluster tasks
- Add fetchNewTasks bool field for indicating whether new tasks should be returned on responding task processing result