### PR TITLE
Add taskState to CrossClusterTaskResponse

### DIFF
--- a/thrift/shared.thrift
+++ b/thrift/shared.thrift
@@ -1819,11 +1819,12 @@ struct CrossClusterTaskRequest {
 struct CrossClusterTaskResponse {
   10: optional i64 (js.type = "Long") taskID
   20: optional CrossClusterTaskType taskType
-  30: optional CrossClusterTaskFailedCause failedCause
-  40: optional CrossClusterStartChildExecutionResponseAttributes startChildExecutionAttributes
-  50: optional CrossClusterCancelExecutionResponseAttributes cancelExecutionAttributes
-  60: optional CrossClusterSignalExecutionResponseAttributes signalExecutionAttributes
-  70: optional CrossClusterRecordChildWorkflowExecutionCompleteResponseAttributes recordChildWorkflowExecutionCompleteAttributes
+  30: optional i16 taskState
+  40: optional CrossClusterTaskFailedCause failedCause
+  50: optional CrossClusterStartChildExecutionResponseAttributes startChildExecutionAttributes
+  60: optional CrossClusterCancelExecutionResponseAttributes cancelExecutionAttributes
+  70: optional CrossClusterSignalExecutionResponseAttributes signalExecutionAttributes
+  80: optional CrossClusterRecordChildWorkflowExecutionCompleteResponseAttributes recordChildWorkflowExecutionCompleteAttributes
 }
 
 struct GetCrossClusterTasksRequest {


### PR DESCRIPTION
Since the execution for a cross cluster task has multiple stages(e.g. for signal execution, there's a signal step and a remove signal mutable state step) and the fact that source cluster may send duplicated x-cluster task requests, we need to know what's the stage the x-cluster task response is for. 