### PR TITLE
Fix firstExecutionRunID type for thrift blobs

### DIFF
--- a/thrift/sqlblobs.thrift
+++ b/thrift/sqlblobs.thrift
@@ -136,7 +136,7 @@ struct WorkflowExecutionInfo {
   120: optional map<string, binary> memo
   122: optional binary versionHistories
   124: optional string versionHistoriesEncoding
-  126: optional string firstExecutionRunID
+  126: optional binary firstExecutionRunID
 }
 
 struct ActivityInfo {


### PR DESCRIPTION
firstExecutionRunID should be binary type in thrift
fix https://github.com/uber/cadence-idl/pull/126