### PR TITLE
Add new pinot visibility message type

### DIFF
--- a/thrift/indexer.thrift
+++ b/thrift/indexer.thrift
@@ -58,3 +58,8 @@ struct Message {
   60: optional map<string,Field> fields
   70: optional VisibilityOperation visibilityOperation
 }
+
+struct PinotMessage {
+  10: optional string workflowID
+  20: optional binary payload
+}


### PR DESCRIPTION
Add new pinot message to publish message to Kafka. We can not use the existing message structure since pinot directly digest from Kafka topic, we have to flatten the message structure.