### PR TITLE
corrects thrift changes to include persistence layer

### DIFF
--- a/thrift/admin.thrift
+++ b/thrift/admin.thrift
@@ -425,31 +425,15 @@ struct ListDynamicConfigResponse {
   10: optional list<config.DynamicConfigEntry> entries
 }
 
-enum IsolationGroupState {
-  INVALID,
-  HEALTHY,
-  DRAINED,
-}
-
-struct IsolationGroupPartition {
-  10: optional string name
-  20: optional IsolationGroupState state
-}
-
-struct IsolationGroupConfiguration {
-  10: optional list<IsolationGroupPartition> isolationGroups
-}
-
-
 // global
 struct GetGlobalIsolationGroupsRequest{}
 
 struct GetGlobalIsolationGroupsResponse{
-    10: optional IsolationGroupConfiguration isolationGroups
+    10: optional shared.IsolationGroupConfiguration isolationGroups
 }
 
 struct UpdateGlobalIsolationGroupsRequest{
-    10: optional IsolationGroupConfiguration isolationGroups
+    10: optional shared.IsolationGroupConfiguration isolationGroups
 }
 
 struct UpdateGlobalIsolationGroupsResponse{}
@@ -461,12 +445,12 @@ struct GetDomainIsolationGroupsRequest{
 }
 
 struct GetDomainIsolationGroupsResponse{
-    10: optional IsolationGroupConfiguration isolationGroups
+    10: optional shared.IsolationGroupConfiguration isolationGroups
 }
 
 struct UpdateDomainIsolationGroupsRequest{
     10: optional string domain
-    20: optional IsolationGroupConfiguration isolationGroups
+    20: optional shared.IsolationGroupConfiguration isolationGroups
 }
 
 struct UpdateDomainIsolationGroupsResponse{}

--- a/thrift/shared.thrift
+++ b/thrift/shared.thrift
@@ -1917,3 +1917,19 @@ struct RespondCrossClusterTasksCompletedRequest {
 struct RespondCrossClusterTasksCompletedResponse {
   10: optional list<CrossClusterTaskRequest> tasks
 }
+
+enum IsolationGroupState {
+  INVALID,
+  HEALTHY,
+  DRAINED,
+}
+
+struct IsolationGroupPartition {
+  10: optional string name
+  20: optional IsolationGroupState state
+}
+
+struct IsolationGroupConfiguration {
+  10: optional list<IsolationGroupPartition> isolationGroups
+}
+

--- a/thrift/sqlblobs.thrift
+++ b/thrift/sqlblobs.thrift
@@ -69,6 +69,7 @@ struct DomainInfo {
   50: optional i64 (js.type = "Long") failoverEndTime
   52: optional i64 (js.type = "Long") previousFailoverVersion
   54: optional i64 (js.type = "Long") lastUpdatedTime
+  56: optional shared.IsolationGroupConfiguration isolationGroupConfiguration
 }
 
 struct HistoryTreeInfo {

--- a/thrift/sqlblobs.thrift
+++ b/thrift/sqlblobs.thrift
@@ -69,7 +69,8 @@ struct DomainInfo {
   50: optional i64 (js.type = "Long") failoverEndTime
   52: optional i64 (js.type = "Long") previousFailoverVersion
   54: optional i64 (js.type = "Long") lastUpdatedTime
-  56: optional shared.IsolationGroupConfiguration isolationGroupConfiguration
+  56: optional binary isolationGroupsConfiguration
+  58: optional string isolationGroupsConfigurationEncoding
 }
 
 struct HistoryTreeInfo {


### PR DESCRIPTION
- Moves the thrift shared components into the `shared` block
- Adds an entry to the domain persistence layer