### PR TITLE
[history] Sync internal WorkflowExecutionInfo with thrift shared

### DIFF
--- a/thrift/shared.thrift
+++ b/thrift/shared.thrift
@@ -391,6 +391,7 @@ struct WorkflowExecutionInfo {
   50: optional WorkflowExecutionCloseStatus closeStatus
   60: optional i64 (js.type = "Long") historyLength
   70: optional string parentDomainId
+  71: optional string parentDomainName
   80: optional WorkflowExecution parentExecution
   90: optional i64 (js.type = "Long") executionTime
   100: optional Memo memo

--- a/thrift/shared.thrift
+++ b/thrift/shared.thrift
@@ -392,6 +392,7 @@ struct WorkflowExecutionInfo {
   60: optional i64 (js.type = "Long") historyLength
   70: optional string parentDomainId
   71: optional string parentDomainName
+  72: optional i64 parentInitatedId
   80: optional WorkflowExecution parentExecution
   90: optional i64 (js.type = "Long") executionTime
   100: optional Memo memo


### PR DESCRIPTION
Adding fields for WorkflowExecutionInfo so we can have roundtrip conversion between internal types WorkflowExecutionInfo and thrift WorkflowExecutionInfo.
These fields exists in proto, but is missing in thrift.