### PR TITLE
Add async workflow config to DomainInfo sql blob

### DIFF
--- a/thrift/sqlblobs.thrift
+++ b/thrift/sqlblobs.thrift
@@ -71,6 +71,8 @@ struct DomainInfo {
   54: optional i64 (js.type = "Long") lastUpdatedTime
   56: optional binary isolationGroupsConfiguration
   58: optional string isolationGroupsConfigurationEncoding
+  60: optional binary asyncWorkflowConfiguration
+  62: optional string asyncWorkflowConfigurationEncoding
 }
 
 struct HistoryTreeInfo {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Adding async workflow config to DomainInfo sql blob. This is needed to be able to persist a domain's async workflow config for sql persistence layers.
A follow up to #156.