### PR TITLE
Global ratelimiter, part 2: Any-typed global ratelimiting APIs for thrift

### DIFF
--- a/thrift/history.thrift
+++ b/thrift/history.thrift
@@ -375,6 +375,30 @@ struct GetFailoverInfoResponse {
   20: optional list<i32> pendingShards
 }
 
+struct RatelimitUpdateRequest {
+  // impl-specific data.
+  // likely some simple top-level keys and then either:
+  // - map<ratelimit-key-string, something>
+  // - list<something>
+  //
+  // this is a single blob rather than a collection to save on
+  // repeated serialization of the type name, and to allow impls
+  // to choose whatever structures are most-convenient for them.
+  10: optional shared.Any data
+}
+
+struct RatelimitUpdateResponse {
+  // impl-specific data.
+  // likely some simple top-level keys and then either:
+  // - map<ratelimit-key-string, something>
+  // - list<something>
+  //
+  // this is a single blob rather than a collection to save on
+  // repeated serialization of the type name, and to allow impls
+  // to choose whatever structures are most-convenient for them.
+  10: optional shared.Any data
+}
+
 /**
 * HistoryService provides API to start a new long running workflow instance, as well as query and update the history
 * of workflow instances already created.
@@ -986,5 +1010,22 @@ service HistoryService {
       2: shared.ServiceBusyError serviceBusyError,
       3: ShardOwnershipLostError shardOwnershipLostError,
       4: shared.EntityNotExistsError entityNotExistError,
+    )
+
+  /**
+  * RatelimitUpdate pushes global-ratelimiting data to aggregating hosts,
+  * and returns data describing how to update the caller's ratelimits.
+  *
+  * For more details, see github.com/uber/cadence/common/quotas/global documentation.
+  *
+  * Request and response structures are intentionally loosely defined, to allow plugging
+  * in externally-defined algorithms without changing protocol-level details.
+  **/
+  RatelimitUpdateResponse RatelimitUpdate(1: RatelimitUpdateRequest request)
+    throws (
+      1: shared.BadRequestError badRequestError,
+      2: shared.InternalServiceError internalServiceError,
+      3: shared.ServiceBusyError serviceBusyError,
+      4: ShardOwnershipLostError shardOwnershipLostError,
     )
 }

--- a/thrift/shared.thrift
+++ b/thrift/shared.thrift
@@ -1969,3 +1969,23 @@ struct AsyncWorkflowConfiguration {
   // queueConfig is the configuration for the queue if predefined_queue_name is not used
   40: optional DataBlob queueConfig
 }
+
+/**
+* Any is a logical duplicate of google.protobuf.Any.
+*
+* The intent of the type is the same, but it is not intended to be directly
+* compatible with google.protobuf.Any or any Thrift equivalent - this blob is
+* RPC-type agnostic by design (as the underlying data may be transported over
+* proto or thrift), and the data-bytes may be in any encoding.
+*
+* See TypeID to interpret the contents.
+**/
+struct Any {
+  // Type-string describing value's contents, and intentionally avoiding the
+  // name "type" as it is often a special term.
+  // This should be a hard-coded string of some kind.
+  10: optional string TypeID
+  // Arbitrarily-encoded bytes, to be deserialized by a runtime implementation.
+  // The contents are described by TypeID.
+  20: optional binary Value
+}

--- a/thrift/shared.thrift
+++ b/thrift/shared.thrift
@@ -1978,14 +1978,19 @@ struct AsyncWorkflowConfiguration {
 * RPC-type agnostic by design (as the underlying data may be transported over
 * proto or thrift), and the data-bytes may be in any encoding.
 *
-* See TypeID to interpret the contents.
+* This is intentionally different from DataBlob, which supports only a handful
+* of known encodings so it can be interpreted everywhere.  Any supports literally
+* any contents, and needs to be considered opaque until it is given to something
+* that is expecting it.
+*
+* See ValueType to interpret the contents.
 **/
 struct Any {
   // Type-string describing value's contents, and intentionally avoiding the
   // name "type" as it is often a special term.
-  // This should be a hard-coded string of some kind.
-  10: optional string TypeID
+  // This should usually be a hard-coded string of some kind.
+  10: optional string ValueType
   // Arbitrarily-encoded bytes, to be deserialized by a runtime implementation.
-  // The contents are described by TypeID.
+  // The contents are described by ValueType.
   20: optional binary Value
 }


### PR DESCRIPTION
This API is purely for inter-Cadence-service use, so the Protobuf equivalent is in the github.com/uber/cadence repository (where it is not randomly exposed to clients): https://github.com/uber/cadence/pull/5817

Design-wise: this has gone through several adjustment and experimenting rounds, and nearly all top-level keys I can come up with are either totally insufficient or totally unnecessary for one ratelimit design or another, so I've leaned more and more towards "define nothing, allow passing anything".

In the extreme, this means: just one `Any` field.  We can add more later if needed / if we discover some kind of truly universal data that is always worth including.
Obviously this is not super ergonomic, but as the ratelimiter is intended to be pluggable by outside implementations it cannot *wholly* be defined in internal protocol definitions.  There needs to be an extendable type of some kind, and arbitrarily requiring e.g. a `list<?>` or `map<string,?>` doesn't actually lend any beneficial semantics to the system, nor reduce space on the wire.

Implementers will need to maintain in-process definitions on both ends of the protocol, and check type IDs before decoding.  Generally speaking this is probably best done with either a shared protobuf-or-something definition (anywhere) or something schema-free like JSON, so cross-version communication can be done safely e.g. during server upgrades.

# Intended use

Eventually this will be part of a pluggable global-ratelimit-data-exchange system, for anything that can make use of the high level "periodically check in to sharded hosts, share data, update limits" pattern that github.com/uber/cadence/common/quotas/global is building up.

The first version will end up using inside-`Any` structures like this:
```go
type Request struct {
  Caller  string             `json:"caller"`
  Elapsed time.Duration      `json:"elapsed"`
  // a compact map[ratelimit key][allowed, rejected] structure.
  // this could be a regular proto/thrift map<string, struct> instead
  // but that'd have lots of repeated field names in JSON
  Data    map[string][2]int  `json:"data"`
}

type Response struct {
  RPS map[ratelimit key]float64  `json:"rps"`
}
```
which will probably just use JSON for simplicity for starters.
Or I'll make a new proto struct and shove that in there instead, using proto-encoded data for both thrift and proto transports.
It doesn't particularly matter.

These request/response structures match the API defined in github.com/uber/cadence/common/quotas/global/algorithm/requestweighted.go , and there will be a fairly simple mapper to convert to/from the `Any` types defined here to make things work.

# Why `Any` instead of strict types?

Because:
- Types we define in these internally-controlled APIs cannot be modified by anyone running Cadence without maintaining a full fork of multiple repos.
- Rate-limiting details are assumed to be relatively unique to internal networking setups, and is therefore not something we intend to fix centrally in every possible variation that server-hosts encounter.

So instead this is loosely typed, and the API will allow Cadence-wrapping developers to add wholly externally defined types as needed, and use DynamicConfig to shadow/enable/disable/etc between any registered algorithms.  If your company needs to e.g. share custom info from Kubernetes to decide how many requests host X can allow (say it's based on number of cores allocated), you will have a relatively simple way to build that and safely try it out.

# Why not `google.protobuf.Any`?

Covered in code comments, but mostly: because that would _require_ using both protobuf _and_ the same protobuf code-generator we use, so the types can be registered and decoded automatically.
That auto-decoding isn't necessary (nor even particularly useful) though, it can be deferred to the ratelimiter-plugin, and then it can be entirely encoding-agnostic.

So that's what this does.  It's not a `google.protobuf.Any` because it doesn't _have_ to be, and you're free to use it if you want.