### PR TITLE
Migrate Buildkite CI queues from AWS to GKE

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,16 +1,42 @@
+container:
+  kubernetes: &kubernetes
+    gitEnvFrom:
+      - secretRef:
+          name: oss-github-ssh-credentials
+    podSpec: &podSpec
+      containers:
+        - &commandContainer
+          image: us-west1-docker.pkg.dev/ci-compute/buildkite-images/buildkite-command-container:v2
+          command:
+          - |-
+            echo "Command step was not overridden."
+            exit 1
+
 steps:
   - label: "fossa analyze"
     agents:
       queue: "buildkite-gcp"
-    command: "./scripts/buildkite/fossa.sh"
+    plugins:
+      - kubernetes:
+          <<: *kubernetes
+          podSpec:
+            <<: *podSpec
+            containers:
+              - <<: *commandContainer
+                command:
+                - |-
+                  ./scripts/buildkite/fossa.sh
+
   - label: "proto lint"
     agents:
       queue: "buildkite-gcp"
     plugins:
       - kubernetes:
+          <<: *kubernetes
           podSpec:
+            <<: *podSpec
             containers:
-              - image: us-west1-docker.pkg.dev/ci-compute/buildkite-images/buildkite-command-container:v2
+              - <<: *commandContainer
                 command:
                 - |-
                   make proto-lint

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,11 +1,16 @@
 steps:
   - label: "fossa analyze"
     agents:
-      queue: "init"
-      docker: "*"
+      queue: "buildkite-gcp"
     command: "./scripts/buildkite/fossa.sh"
   - label: "proto lint"
     agents:
-      queue: "workers"
-      docker: "*"
-    command: "make proto-lint"
+      queue: "buildkite-gcp"
+    plugins:
+      - kubernetes:
+          podSpec:
+            containers:
+              - image: us-west1-docker.pkg.dev/ci-compute/buildkite-images/buildkite-command-container:v2
+                command:
+                - |-
+                  make proto-lint


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Update Buildkite pipeline yaml to work with the newly provisioned queues in Google Kubernetes Engine
- Use [agent-stack-k8s v0.8.0 helm chart](https://github.com/buildkite/agent-stack-k8s/tree/v0.8.0?tab=readme-ov-file#cloning-repos-via-ssh) which has its own expected pipeline yaml syntax in order to successfully onboard. 

<!-- Tell your future self why have you made these changes -->
**Why?**
- There is a company mandate to evacuate Uber's AWS CI footprint. The go forward decision is to use Google Cloud. Buildkite Enterprise recommends GKE (as opposed to GCP) as the way to have a queue with autoscaling compute. 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- https://buildkite.com/uberopensource/cadence-idl/builds/518

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
- CI builds will be broken or flaky
- Can be mitigated by a git revert

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**
n/a

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
n/a
