### PR TITLE
Add a usage-data return type to ratelimiters

### DIFF
--- a/thrift/history.thrift
+++ b/thrift/history.thrift
@@ -443,12 +443,32 @@ struct WeightedRatelimitCalls {
 * used in an Any with ValueType: WeightedRatelimitQuotasAnyType
 */
 struct WeightedRatelimitQuotas {
-  /** RPS to allow per key */
+  /** RPS-weights to allow per key */
   10: required map<string,double> quotas
 }
 
 /** Any{ValueType} identifier for WeightedRatelimitQuotas data */
 const string WeightedRatelimitQuotasAnyType = "cadence:loadbalanced:update_response"
+
+/**
+* second impl, includes unused-RPS data so limiters can decide if they
+* want to allow exceeding limits when there is free space.
+*
+* used in an Any with ValueType: WeightedRatelimitUsageQuotasAnyType
+*/
+struct WeightedRatelimitUsageQuotas {
+  /** RPS weights and total usage per key */
+  10: required map<string,WeightedRatelimitUsageQuotaEntry> quotas
+}
+
+struct WeightedRatelimitUsageQuotaEntry {
+  /** Amount of the quota that the receiving host can use, between 0 and 1 */
+  10: required double weight
+  /** RPS estimated across the whole cluster */
+  20: required double used
+}
+
+const string WeightedRatelimitUsageQuotasAnyType = "cadence:loadbalanced:update_response_used"
 
 /**
 * HistoryService provides API to start a new long running workflow instance, as well as query and update the history


### PR DESCRIPTION
IDL changes needed to build https://github.com/uber/cadence/pull/6238

Basically this is just: return the "used RPS" that was already being tracked.

For compatibility purposes: while deploying, this will lead to version-crossing requests failing due to an unknown type, which will eventually put those keys into the "failing" mode.
This is currently _intended_, to serve as a full test of that fallback system, but should not be done in general.

Due to a different test (broken hashring) we have already seen the fallback system kick in correctly, so I'm fairly confident that this will work as intended.  Still, it's probably worth testing, particularly because it's easy.

---

This only changes thrift because this type is serialized _outside_ RPC, just like our database types.  There is no proto equivalent, at best it'd be these-serialized-thrift-bytes sent in a proto wrapper.