### PR TITLE
Add matching CompleteStartedTask thrift idl

### DIFF
--- a/thrift/matching.thrift
+++ b/thrift/matching.thrift
@@ -131,6 +131,15 @@ struct ListTaskListPartitionsRequest {
   20: optional shared.TaskList taskList
 }
 
+struct CompleteStartedTaskRequest {
+  10: optional string domainUUID
+  20: optional shared.WorkflowExecution execution
+  30: optional i64 (js.type = "Long") scheduleId
+}
+
+struct CompleteStartedTaskResponse {
+}
+
 /**
 * MatchingService API is exposed to provide support for polling from long running applications.
 * Such applications are expected to have a worker which regularly polls for DecisionTask and ActivityTask.  For each
@@ -270,5 +279,15 @@ service MatchingService {
         1: shared.BadRequestError badRequestError,
         2: shared.InternalServiceError internalServiceError,
         4: shared.ServiceBusyError serviceBusyError,
+    )
+
+  /**
+  * CompleteStartedTask is called by the history service when it receives a task started event has been replicated
+  **/
+  CompleteStartedTaskResponse CompleteStartedTask(1: CompleteStartedTaskRequest request)
+    throws (
+      1: shared.BadRequestError badRequestError,
+      2: shared.ServiceBusyError serviceBusyError,
+      3: shared.LimitExceededError limitExceededError,
     )
 }


### PR DESCRIPTION
### Summary
This endpoint will be called by the history service in order to complete a task in matching after it has been replicated in history.
This will allow cadence to actively delete stale tasks from matching on the passive side as these tasks are processed on the active side and replicated, avoiding the large passive side partitions and reducing task processing latency after a failover

### Type of Change
- [x] Add new API(s)
- [ ] Add new data type(s)
- [ ] Add new field(s) to existing data type
- [ ] Remove field(s) from data type
- [ ] Remove data type(s)
- [ ] Remove API(s)
- [ ] Other (please provide detailed description)

### Data Effect
- [ ] Does it change the data stored in database?

### Detailed Description
Added the CompleteStartedTask endpoint, with the following:

CompleteStartedTaskRequest:
- domainUUID
- execution (workflowId, runId)
- scheduleId

CompleteStartedTaskResponse (no fields)

### Impact Analysis
- **Backward Compatibility**: new internal API
- **Forward Compatibility**: created response for forward compatibility

### Testing Plan
- **Unit Tests**: [Do we have unit test covering the change?]
- **Persistence Tests**: [If the change is related to a data type which is persisted, do we have persistence tests covering the change?]
- **Integration Tests**: [Do we have integration test covering the change?]
- **Compatibility Tests**: [Have we done tests to test the backward and forward compatibility?]

### Rollout Plan
- What is the rollout plan?
- Does the order of deployment matter?
- Is it safe to rollback? Does the order of rollback matter?
- Is there a kill switch to mitigate the impact immediately?
